### PR TITLE
Add Arena method to Skiplist

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -65,7 +65,7 @@ func (it *Iterator) Value() []byte {
 	return it.arena.GetBytes(valOffset, valSize)
 }
 
-// Value returns the metadata at the current position.
+// Meta returns the metadata at the current position.
 func (it *Iterator) Meta() uint16 {
 	return decodeMeta(it.value)
 }

--- a/skl.go
+++ b/skl.go
@@ -125,9 +125,10 @@ func NewSkiplist(arena *Arena) *Skiplist {
 
 // Height returns the height of the highest tower within any of the nodes that
 // have ever been allocated as part of this skiplist.
-func (s *Skiplist) Height() uint32 {
-	return atomic.LoadUint32(&s.height)
-}
+func (s *Skiplist) Height() uint32 { return atomic.LoadUint32(&s.height) }
+
+// Arena returns the arena backing this skiplist.
+func (s *Skiplist) Arena() *Arena { return s.arena }
 
 // Size returns the number of bytes that have allocated from the arena.
 func (s *Skiplist) Size() uint32 { return s.arena.Size() }


### PR DESCRIPTION
Add method that provides access to the arena backing a skiplist. This will be used in CockroachDB to allow arena re-use when cycling `intervalSkl` pages.

@andy-kimball I'm not sure if your intention was to maintain this library or if it was just an initial code dump. Because the library is so self-contained, I can't imagine it will undergo very much change going forward. Still, if maintaining the library becomes a burden, Cockroach can always maintain a fork ourselves.