### PR TITLE
Increase key size from 64K to 4G

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -62,7 +62,7 @@ func (a *Arena) Reset() {
 	atomic.StoreUint32(&a.n, 1)
 }
 
-func (a *Arena) Alloc(size uint16, align Align) (uint32, error) {
+func (a *Arena) Alloc(size uint32, align Align) (uint32, error) {
 	// Pad the allocation with enough bytes to ensure the requested alignment.
 	padded := uint32(size) + uint32(align)
 
@@ -76,12 +76,12 @@ func (a *Arena) Alloc(size uint16, align Align) (uint32, error) {
 	return offset, nil
 }
 
-func (a *Arena) GetBytes(offset uint32, size uint16) []byte {
+func (a *Arena) GetBytes(offset uint32, size uint32) []byte {
 	if offset == 0 {
 		return nil
 	}
 
-	return a.buf[offset : offset+uint32(size)]
+	return a.buf[offset : offset+size]
 }
 
 func (a *Arena) GetPointer(offset uint32) unsafe.Pointer {

--- a/iterator.go
+++ b/iterator.go
@@ -62,7 +62,7 @@ func (it *Iterator) Key() []byte {
 // Value returns the value at the current position.
 func (it *Iterator) Value() []byte {
 	valOffset, valSize := decodeValue(it.value)
-	return it.arena.GetBytes(valOffset, valSize)
+	return it.arena.GetBytes(valOffset, uint32(valSize))
 }
 
 // Meta returns the metadata at the current position.

--- a/node.go
+++ b/node.go
@@ -34,10 +34,7 @@ func (l *links) init(prevOffset, nextOffset uint32) {
 type node struct {
 	// Immutable fields, so no need to lock to access key.
 	keyOffset uint32
-	keySize   uint16
-
-	// Height of this node's tower.
-	height uint16
+	keySize   uint32
 
 	// Multiple parts of the value are encoded as a single uint64 so that it
 	// can be atomically loaded and stored:
@@ -65,19 +62,17 @@ func newNode(arena *Arena, height uint32) (nd *node, err error) {
 	// is less than maxHeight.
 	unusedSize := (maxHeight - int(height)) * linksSize
 
-	nodeOffset, err := arena.Alloc(uint16(MaxNodeSize-unusedSize), Align8)
+	nodeOffset, err := arena.Alloc(uint32(MaxNodeSize-unusedSize), Align8)
 	if err != nil {
 		return
 	}
 
 	nd = (*node)(arena.GetPointer(nodeOffset))
-	nd.height = uint16(height)
-
 	return
 }
 
 func (n *node) getKey(arena *Arena) []byte {
-	return arena.GetBytes(n.keyOffset, uint16(n.keySize))
+	return arena.GetBytes(n.keyOffset, n.keySize)
 }
 
 func (n *node) nextOffset(h int) uint32 {

--- a/skl.go
+++ b/skl.go
@@ -171,12 +171,12 @@ func (s *Skiplist) randomHeight() uint32 {
 	return h
 }
 
-func (s *Skiplist) allocKey(key []byte) (keyOffset uint32, keySize uint16, err error) {
-	if len(key) > math.MaxUint16 {
+func (s *Skiplist) allocKey(key []byte) (keyOffset uint32, keySize uint32, err error) {
+	if len(key) > math.MaxUint32 {
 		panic("key is too large")
 	}
 
-	keySize = uint16(len(key))
+	keySize = uint32(len(key))
 	keyOffset, err = s.arena.Alloc(keySize, Align1)
 	if err == nil {
 		copy(s.arena.GetBytes(keyOffset, keySize), key)
@@ -191,13 +191,12 @@ func (s *Skiplist) allocVal(val []byte, meta uint16) (uint64, error) {
 	}
 
 	valSize := uint16(len(val))
-
-	valOffset, err := s.arena.Alloc(valSize, Align1)
+	valOffset, err := s.arena.Alloc(uint32(valSize), Align1)
 	if err != nil {
 		return 0, err
 	}
 
-	copy(s.arena.GetBytes(valOffset, valSize), val)
+	copy(s.arena.GetBytes(valOffset, uint32(valSize)), val)
 	return encodeValue(valOffset, valSize, meta), nil
 }
 


### PR DESCRIPTION
This change changes the `node.keySize` field from a `uint16` to a
`uint32`, which increases the maximum key size from `64K` to `4G`.
This was possible without increasing the node size by removing the
unused `height` field.

See https://github.com/cockroachdb/cockroach/issues/20389.