### PR TITLE
Protect against accounting overflow in Arena allocation

### DIFF
--- a/arena_test.go
+++ b/arena_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ * Modifications copyright (C) 2017 Andy Kimball and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package arenaskl
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestArenaSizeOverflow tests that large allocations do not cause Arena's
+// internal size accounting to overflow and produce incorrect results.
+func TestArenaSizeOverflow(t *testing.T) {
+	a := NewArena(math.MaxUint32)
+
+	// Allocating under the limit throws no error.
+	offset, err := a.Alloc(math.MaxUint16, Align1)
+	require.Nil(t, err)
+	require.Equal(t, uint32(1), offset)
+	require.Equal(t, uint32(math.MaxUint16)+1, a.Size())
+
+	// Allocating over the limit could cause an accounting
+	// overflow if 32-bit arithmetic was used. It shouldn't.
+	_, err = a.Alloc(math.MaxUint32, Align1)
+	require.Equal(t, ErrArenaFull, err)
+	require.Equal(t, uint32(math.MaxUint32), a.Size())
+
+	// Continuing to allocate continues to throw an error.
+	_, err = a.Alloc(math.MaxUint16, Align1)
+	require.Equal(t, ErrArenaFull, err)
+	require.Equal(t, uint32(math.MaxUint32), a.Size())
+}

--- a/skl_test.go
+++ b/skl_test.go
@@ -475,7 +475,7 @@ func TestConcurrentAdd(t *testing.T) {
 	}
 
 	for f := 0; f < 2; f++ {
-		go func() {
+		go func(id int) {
 			var it Iterator
 			it.Init(l)
 
@@ -483,7 +483,7 @@ func TestConcurrentAdd(t *testing.T) {
 				start[i].Wait()
 
 				key := newValue(i)
-				val := []byte(fmt.Sprintf("%d: %05d", f, i))
+				val := []byte(fmt.Sprintf("%d: %05d", id, i))
 				if it.Add(key, val, 0) == nil {
 					it.Seek(key)
 					require.EqualValues(t, val, it.Value())
@@ -491,7 +491,7 @@ func TestConcurrentAdd(t *testing.T) {
 
 				end[i].Done()
 			}
-		}()
+		}(f)
 	}
 
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
This change protects against large allocations causing Arena's
internal size accounting to overflow and produce incorrect results.
This overflow could allow for invalid offsets being returned from
`Arena.Alloc`, leading to slice bounds and index out of range panics
when passed to `Arena.GetBytes` or `Arena.GetPointer`.

Specifically, if `Arena.n` overflowed in `Arena.Alloc`, which was
possible because it was a uint32 and we allow up to MaxUint32 size
allocations, then `Arena.Alloc` could bypass the length check against
`Arena.buf`. The "padded" size would then be subtracted from the offset,
allowing the offset to underflow back around to an offset that was out
of `Arena.buf`'s bounds.

I believe this is the underlying cause of the following two crashes:
- cockroachdb/cockroach#31624
- cockroachdb/cockroach#35557

The reason for this is subtle and has to do with failed allocations
slowly building up and eventually overflowing `Arena.n`. I'll explain
on the PR that vendors this fix.

We now protect against this overflow in two ways. We perform an initial
size check before performing the atomic addition in `Arena.Alloc` to
prevent failed allocations from "building up" to an overflow. We also
use 64-bit arithmetic so that it would take 2^32 concurrent allocations
with the maximum allocation size (math.MaxUint32) to overflow the
accounting. An alternative would be to use a CAS loop to strictly
serialize all additions to `Arena.n`, but that would limit concurrency.