### PR TITLE
Issue 5: Fix build error on ARM 32-bit architecture

### DIFF
--- a/skl.go
+++ b/skl.go
@@ -172,11 +172,11 @@ func (s *Skiplist) randomHeight() uint32 {
 }
 
 func (s *Skiplist) allocKey(key []byte) (keyOffset uint32, keySize uint32, err error) {
-	if len(key) > math.MaxUint32 {
+	keySize = uint32(len(key))
+	if keySize > math.MaxUint32 {
 		panic("key is too large")
 	}
 
-	keySize = uint32(len(key))
 	keyOffset, err = s.arena.Alloc(keySize, Align1)
 	if err == nil {
 		copy(s.arena.GetBytes(keyOffset, keySize), key)


### PR DESCRIPTION
Library builds correctly on ARM, and all tests run except for
TestArenaSizeOverflow (which is not really important for this case).

Fixes #5 