### PR TITLE
Ensure entire node points to allocated memory

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -68,7 +68,7 @@ func (a *Arena) Reset() {
 	atomic.StoreUint64(&a.n, 1)
 }
 
-func (a *Arena) Alloc(size uint32, align Align) (uint32, error) {
+func (a *Arena) Alloc(size, overflow uint32, align Align) (uint32, error) {
 	// Verify that the arena isn't already full.
 	origSize := atomic.LoadUint64(&a.n)
 	if int(origSize) > len(a.buf) {
@@ -80,7 +80,7 @@ func (a *Arena) Alloc(size uint32, align Align) (uint32, error) {
 
 	// Use 64-bit arithmetic to protect against overflow.
 	newSize := atomic.AddUint64(&a.n, uint64(padded))
-	if int(newSize) > len(a.buf) {
+	if int(newSize)+int(overflow) > len(a.buf) {
 		// Doubles as a check against newSize > math.MaxUint32.
 		return 0, ErrArenaFull
 	}

--- a/arena_test.go
+++ b/arena_test.go
@@ -30,19 +30,19 @@ func TestArenaSizeOverflow(t *testing.T) {
 	a := NewArena(math.MaxUint32)
 
 	// Allocating under the limit throws no error.
-	offset, err := a.Alloc(math.MaxUint16, Align1)
+	offset, err := a.Alloc(math.MaxUint16, 0, Align1)
 	require.Nil(t, err)
 	require.Equal(t, uint32(1), offset)
 	require.Equal(t, uint32(math.MaxUint16)+1, a.Size())
 
 	// Allocating over the limit could cause an accounting
 	// overflow if 32-bit arithmetic was used. It shouldn't.
-	_, err = a.Alloc(math.MaxUint32, Align1)
+	_, err = a.Alloc(math.MaxUint32, 0, Align1)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(math.MaxUint32), a.Size())
 
 	// Continuing to allocate continues to throw an error.
-	_, err = a.Alloc(math.MaxUint16, Align1)
+	_, err = a.Alloc(math.MaxUint16, 0, Align1)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(math.MaxUint32), a.Size())
 }

--- a/node.go
+++ b/node.go
@@ -62,7 +62,7 @@ func newNode(arena *Arena, height uint32) (nd *node, err error) {
 	// is less than maxHeight.
 	unusedSize := (maxHeight - int(height)) * linksSize
 
-	nodeOffset, err := arena.Alloc(uint32(MaxNodeSize-unusedSize), Align8)
+	nodeOffset, err := arena.Alloc(uint32(MaxNodeSize-unusedSize), uint32(unusedSize), Align8)
 	if err != nil {
 		return
 	}

--- a/race_test.go
+++ b/race_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ * Modifications copyright (C) 2020 Andy Kimball and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// +build race
+
+package arenaskl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeArenaEnd tests allocating a node at the boundary of an arena. In Go
+// 1.14 when the race detector is running, Go will also perform some pointer
+// alignment checks. It will detect alignment issues where a node's memory would
+// straddle the arena boundary, with unused regions of the node struct dipping
+// into unallocated memory. This test is only run when the race build tag is
+// provided.
+func TestNodeArenaEnd(t *testing.T) {
+	// Rather than hardcode an arena size at just the right size, try
+	// allocating using successively larger arena sizes until we allocate
+	// successfully. The prior attempt will have exercised the right code
+	// path.
+	for i := uint32(1); i < 256; i++ {
+		a := NewArena(i)
+		_, err := newNode(a, 1)
+		if err == nil {
+			// We reached an arena size big enough to allocate a node. If
+			// there's an issue at the boundary, the race detector would have
+			// found it by now.
+			t.Log(i)
+			break
+		}
+		require.Equal(t, ErrArenaFull, err)
+	}
+}

--- a/skl.go
+++ b/skl.go
@@ -177,7 +177,7 @@ func (s *Skiplist) allocKey(key []byte) (keyOffset uint32, keySize uint32, err e
 		panic("key is too large")
 	}
 
-	keyOffset, err = s.arena.Alloc(keySize, Align1)
+	keyOffset, err = s.arena.Alloc(keySize, 0 /* overflow */, Align1)
 	if err == nil {
 		copy(s.arena.GetBytes(keyOffset, keySize), key)
 	}
@@ -191,7 +191,7 @@ func (s *Skiplist) allocVal(val []byte, meta uint16) (uint64, error) {
 	}
 
 	valSize := uint16(len(val))
-	valOffset, err := s.arena.Alloc(uint32(valSize), Align1)
+	valOffset, err := s.arena.Alloc(uint32(valSize), 0 /* overflow */, Align1)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Adapted from https://github.com/cockroachdb/pebble/pull/669. Only a
few small changes were needed to, presumably because pebble's fork
of this library has diverged slightly.

Previously, if a node was allocated at the end of the arena, the node
struct could straddle the end of the arena, with the unused links
extending into unallocated memory.

Go 1.14 adds a checkptr check to -race builds that checks for pointer
alignment issues, and it flags the conversion of these
partially-allocated nodes at the arena boundary.

This commit changes the allocation logic to grow the arena such that the
entirety of the last node struct is allocated.