### PR TITLE
Add Cap method to Arena

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -64,6 +64,10 @@ func (a *Arena) Size() uint32 {
 	return uint32(s)
 }
 
+func (a *Arena) Cap() uint32 {
+	return uint32(len(a.buf))
+}
+
 func (a *Arena) Reset() {
 	atomic.StoreUint64(&a.n, 1)
 }


### PR DESCRIPTION
This is useful for knowing how large the arena is when recycling old
memory arenas.