### PR TITLE
Use lock-free random number generator for node height selection

### DIFF
--- a/internal/fastrand/fastrand.go
+++ b/internal/fastrand/fastrand.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ * Modifications copyright (C) 2020 Andy Kimball and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fastrand
+
+import _ "unsafe" // required by go:linkname
+
+// Uint32 returns a lock free uint32 value.
+//go:linkname Uint32 runtime.fastrand
+func Uint32() uint32

--- a/internal/fastrand/fastrand_test.go
+++ b/internal/fastrand/fastrand_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ * Modifications copyright (C) 2020 Andy Kimball and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fastrand
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// Results with go1.13.12 on a Mac with a 2.3 GHz 8-Core Intel Core i9 processor:
+//
+// $ go test -cpu 1,2,4,8,16,32 -bench=. -count=1 | benchstat /dev/stdin
+//
+//   name            time/op
+//   FastRand        2.25ns ± 2%
+//   FastRand-2      1.14ns ± 3%
+//   FastRand-4      0.59ns ± 4%
+//   FastRand-8      0.35ns ± 6%
+//   FastRand-16     0.33ns ± 4%
+//   FastRand-32     0.32ns ± 2%
+//   DefaultRand     13.3ns ± 3%
+//   DefaultRand-2   19.2ns ± 3%
+//   DefaultRand-4   41.5ns ± 1%
+//   DefaultRand-8   56.7ns ± 1%
+//   DefaultRand-16  66.6ns ±12%
+//   DefaultRand-32  65.8ns ± 6%
+//
+
+func BenchmarkFastRand(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			Uint32()
+		}
+	})
+}
+
+func BenchmarkDefaultRand(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			rand.Uint32()
+		}
+	})
+}

--- a/race_test.go
+++ b/race_test.go
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// +build race
-
 package arenaskl
 
 import (

--- a/skl.go
+++ b/skl.go
@@ -47,9 +47,10 @@ import (
 	"bytes"
 	"errors"
 	"math"
-	"math/rand"
 	"sync/atomic"
 	"unsafe"
+
+	"github.com/andy-kimball/arenaskl/internal/fastrand"
 )
 
 const (
@@ -162,7 +163,7 @@ func (s *Skiplist) newNode(key, val []byte, meta uint16) (nd *node, height uint3
 }
 
 func (s *Skiplist) randomHeight() uint32 {
-	rnd := rand.Uint32()
+	rnd := fastrand.Uint32()
 	h := uint32(1)
 	for h < maxHeight && rnd <= probabilities[h] {
 		h++

--- a/skl_test.go
+++ b/skl_test.go
@@ -743,8 +743,7 @@ func randomKey(rng *rand.Rand) []byte {
 	return b
 }
 
-// Standard test. Some fraction is read. Some fraction is write. Writes have
-// to go through mutex lock.
+// Standard test. Some fraction is read. Some fraction is write.
 func BenchmarkReadWrite(b *testing.B) {
 	value := newValue(123)
 	for i := 0; i <= 10; i++ {


### PR DESCRIPTION
Fixes #9.

Inspired by https://github.com/cockroachdb/pebble/pull/742.

This commit replaces the use of the standard library's global random number generator `rand.globalRand` with the lock-free pseudo-rng provided by the runtime and backed by thread-local storage [`runtime.fastrand`](https://golang.org/pkg/runtime/?m=all#fastrand).

This same rng is used in other performance-critical operations, such as in `sync.Pool`'s decision as to whether to drop objects or retain them.

```
name                     old time/op    new time/op    delta
ReadWrite/frac_0-16         380ns ± 7%     324ns ± 3%  -14.75%  (p=0.000 n=10+10)
ReadWrite/frac_30-16        314ns ± 8%     273ns ± 6%  -12.92%  (p=0.000 n=10+10)
ReadWrite/frac_10-16        350ns ± 6%     306ns ± 6%  -12.38%  (p=0.000 n=10+10)
ReadWrite/frac_20-16        328ns ± 9%     291ns ± 4%  -11.52%  (p=0.000 n=10+9)
ReadWrite/frac_40-16        289ns ± 4%     256ns ± 4%  -11.26%  (p=0.000 n=9+9)
ReadWrite/frac_60-16        237ns ± 6%     214ns ± 4%   -9.58%  (p=0.000 n=10+9)
ReadWrite/frac_50-16        262ns ± 6%     237ns ± 4%   -9.52%  (p=0.000 n=10+10)
ReadWrite/frac_70-16        213ns ± 2%     194ns ± 2%   -8.87%  (p=0.000 n=9+10)
ReadWrite/frac_80-16        176ns ± 3%     171ns ± 7%   -2.85%  (p=0.009 n=9+9)
ReadWrite/frac_90-16        135ns ± 3%     135ns ± 9%     ~     (p=0.303 n=9+10)
ReadWrite/frac_100-16      7.03ns ±11%    6.99ns ±12%     ~     (p=0.748 n=9+9)
```